### PR TITLE
Layout issue > Photo page footers

### DIFF
--- a/Source/Pages/Gallery/BottomPager/YPPagerMenu.swift
+++ b/Source/Pages/Gallery/BottomPager/YPPagerMenu.swift
@@ -16,15 +16,26 @@ final class YPPagerMenu: UIView {
     
     convenience init() {
         self.init(frame: .zero)
-        backgroundColor = UIColor(r: 247, g: 247, b: 247)
+        backgroundColor = UIColor(r: 255, g: 255, b: 255)
         clipsToBounds = true
     }
     
     var separators = [UIView]()
     
+    let line = UIView()
+    
     func setUpMenuItemsConstraints() {
         let menuItemWidth: CGFloat = UIScreen.main.bounds.width / CGFloat(menuItems.count)
         var previousMenuItem: YPMenuItem?
+        
+        line.backgroundColor = UIColor(r: 204, g: 204, b: 204)
+        sv(line)
+        
+        layout(
+            0,
+            |line.height(1)|
+        )
+        
         for m in menuItems {
             
             sv(

--- a/Source/YPPickerVC.swift
+++ b/Source/YPPickerVC.swift
@@ -46,7 +46,7 @@ public class YPPickerVC: YPBottomPager, YPBottomPagerDelegate {
     public override func viewDidLoad() {
         super.viewDidLoad()
         
-        view.backgroundColor = UIColor(r: 247, g: 247, b: 247)
+        view.backgroundColor = UIColor(r: 255, g: 255, b: 255)
         
         delegate = self
         


### PR DESCRIPTION
Part of ticket (https://app.asana.com/0/1131999008442065/1131990074040348)

> Please make the footer of the Camera page (with the Camera and Photos options) to be the same style as the Filter page. So the footer background should be white with a line above it. 